### PR TITLE
Connect example user from API to Unity

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -323,6 +323,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 78e3c97c1d8b790499c2af3b3a52c0c0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  apiUrl: https://gts-api-p9ar.onrender.com/api
+  username: dave
   startingMoney: 100
 --- !u!4 &220861225
 Transform:

--- a/Assets/Scripts/API.meta
+++ b/Assets/Scripts/API.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 408b5dd7eeb05514988aea44a056e89a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/API/HTTPRequests.cs
+++ b/Assets/Scripts/API/HTTPRequests.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.Networking;

--- a/Assets/Scripts/API/HTTPRequests.cs
+++ b/Assets/Scripts/API/HTTPRequests.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using UnityEngine;
+using UnityEngine.Networking;
+
+public static class HTTPRequests<T>
+{
+    public static async Task<T> Get(string url)
+    {
+        
+    }
+}

--- a/Assets/Scripts/API/HTTPRequests.cs
+++ b/Assets/Scripts/API/HTTPRequests.cs
@@ -13,6 +13,10 @@ public static class HTTPRequests<T>
         http.method = "GET";
         http.SetRequestHeader("Content-Type", "application/json");
 
+        UnityWebRequestAsyncOperation req = http.SendWebRequest();
+
+        while (!req.isDone) await Task.Yield();
+
         
     }
 }

--- a/Assets/Scripts/API/HTTPRequests.cs
+++ b/Assets/Scripts/API/HTTPRequests.cs
@@ -17,6 +17,10 @@ public static class HTTPRequests<T>
 
         while (!req.isDone) await Task.Yield();
 
+        string response = http.downloadHandler.text;
+
+        if (http.result != UnityWebRequest.Result.Success) Debug.LogError(http.error);
+
         
     }
 }

--- a/Assets/Scripts/API/HTTPRequests.cs
+++ b/Assets/Scripts/API/HTTPRequests.cs
@@ -9,6 +9,10 @@ public static class HTTPRequests<T>
 {
     public static async Task<T> Get(string url)
     {
+        UnityWebRequest http = UnityWebRequest.Get(url);
+        http.method = "GET";
+        http.SetRequestHeader("Content-Type", "application/json");
+
         
     }
 }

--- a/Assets/Scripts/API/HTTPRequests.cs
+++ b/Assets/Scripts/API/HTTPRequests.cs
@@ -25,8 +25,6 @@ public static class HTTPRequests<T>
 
         string response = http.downloadHandler.text;
 
-        // Check if the request was successful.
-        // If not, early return with an error log.
         if (http.result != UnityWebRequest.Result.Success)
         {
             Debug.LogError(http.error);
@@ -37,7 +35,7 @@ public static class HTTPRequests<T>
         // Attempt to parse the JSON result to an Object that represents the data.
         try
         {
-            T result = JsonUtility.FromJson<T>(response);
+            T result = JsonUtility.FromJson<T>(response); // Converts the JSON to the 'T' type provided whenever the method is called.
 
             Debug.Log(http.downloadHandler.text);
 

--- a/Assets/Scripts/API/HTTPRequests.cs
+++ b/Assets/Scripts/API/HTTPRequests.cs
@@ -19,8 +19,26 @@ public static class HTTPRequests<T>
 
         string response = http.downloadHandler.text;
 
-        if (http.result != UnityWebRequest.Result.Success) Debug.LogError(http.error);
+        if (http.result != UnityWebRequest.Result.Success)
+        {
+            Debug.LogError(http.error);
 
-        
+            return default;
+        }
+
+        try
+        {
+            T result = JsonUtility.FromJson<T>(response);
+
+            Debug.Log(http.downloadHandler.text);
+
+            return result;
+        }
+        catch (Exception ex)
+        {
+            Debug.LogError(ex.Message);
+
+            return default;
+        }
     }
 }

--- a/Assets/Scripts/API/HTTPRequests.cs
+++ b/Assets/Scripts/API/HTTPRequests.cs
@@ -5,6 +5,10 @@ using System.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.Networking;
 
+/// <summary>
+/// Handles all HTTP requests that the game requires to function.
+/// </summary>
+
 public class HTTPRequests
 {
     public static async Task<T> Get<T>(string url)

--- a/Assets/Scripts/API/HTTPRequests.cs
+++ b/Assets/Scripts/API/HTTPRequests.cs
@@ -37,7 +37,9 @@ public class HTTPRequests
         // Attempt to parse the JSON result to an Object that represents the data.
         try
         {
-            T result = JsonUtility.FromJson<T>(response); // Converts the JSON to the 'T' type provided whenever the method is called.
+            // Due to the way our API formats responses, the extra 'data' step is necessary.
+            Data<T> data = JsonUtility.FromJson<Data<T>>(response); // Converts the JSON to the 'T' type provided whenever the method is called.
+            T result = data.data;
 
             Debug.Log(http.downloadHandler.text);
 

--- a/Assets/Scripts/API/HTTPRequests.cs
+++ b/Assets/Scripts/API/HTTPRequests.cs
@@ -5,9 +5,9 @@ using System.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.Networking;
 
-public static class HTTPRequests<T>
+public class HTTPRequests
 {
-    public static async Task<T> Get(string url)
+    public static async Task<T> Get<T>(string url)
     {
         // Create a new GET request.
         // Similar to the 'options' parameter of a javascript request.

--- a/Assets/Scripts/API/HTTPRequests.cs
+++ b/Assets/Scripts/API/HTTPRequests.cs
@@ -9,16 +9,24 @@ public static class HTTPRequests<T>
 {
     public static async Task<T> Get(string url)
     {
+        // Create a new GET request.
+        // Similar to the 'options' parameter of a javascript request.
         UnityWebRequest http = UnityWebRequest.Get(url);
         http.method = "GET";
         http.SetRequestHeader("Content-Type", "application/json");
 
+        // Make the request to the API.
+        // Similar to running 'fetch(url, options)'.
         UnityWebRequestAsyncOperation req = http.SendWebRequest();
 
-        while (!req.isDone) await Task.Yield();
+        // Wait until request is finished.
+        // 'Task.Yield()' waits until the condition is true to continue without slowing down other processes.
+        while (!req.isDone) await Task.Yield(); 
 
         string response = http.downloadHandler.text;
 
+        // Check if the request was successful.
+        // If not, early return with an error log.
         if (http.result != UnityWebRequest.Result.Success)
         {
             Debug.LogError(http.error);
@@ -26,6 +34,7 @@ public static class HTTPRequests<T>
             return default;
         }
 
+        // Attempt to parse the JSON result to an Object that represents the data.
         try
         {
             T result = JsonUtility.FromJson<T>(response);
@@ -38,7 +47,7 @@ public static class HTTPRequests<T>
         {
             Debug.LogError(ex.Message);
 
-            return default;
+            return default; // Essentially returning null but ensuring that non-nullable types still work.
         }
     }
 }

--- a/Assets/Scripts/API/HTTPRequests.cs.meta
+++ b/Assets/Scripts/API/HTTPRequests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 666aa277796c559499d213982c9b4b7d

--- a/Assets/Scripts/API/Types.meta
+++ b/Assets/Scripts/API/Types.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a1278021a8fe4a54d917ae32f94c1787
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/API/Types/Data.cs
+++ b/Assets/Scripts/API/Types/Data.cs
@@ -1,0 +1,8 @@
+using System;
+
+
+[Serializable]
+public class Data<T>
+{
+    public T data;
+}

--- a/Assets/Scripts/API/Types/Data.cs
+++ b/Assets/Scripts/API/Types/Data.cs
@@ -1,5 +1,11 @@
 using System;
 
+/// <summary>
+/// Required when retrieving data from the game's API to destructure the result correctly.
+/// </summary>
+/// <typeparam name="T">
+/// Use the desired 'table' type as this will store the require data in <c>data</c>.
+/// </typeparam>
 
 [Serializable]
 public class Data<T>

--- a/Assets/Scripts/API/Types/Data.cs.meta
+++ b/Assets/Scripts/API/Types/Data.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 424280b16b2fbda4a8c1511d50d4cbc4

--- a/Assets/Scripts/API/Types/User.cs
+++ b/Assets/Scripts/API/Types/User.cs
@@ -4,5 +4,7 @@ using UnityEngine;
 [Serializable]
 public class User
 {
-    
+    public string id;
+    public string name;
+    public double money;
 }

--- a/Assets/Scripts/API/Types/User.cs
+++ b/Assets/Scripts/API/Types/User.cs
@@ -1,0 +1,8 @@
+using System;
+using UnityEngine;
+
+[Serializable]
+public class User
+{
+    
+}

--- a/Assets/Scripts/API/Types/User.cs
+++ b/Assets/Scripts/API/Types/User.cs
@@ -1,7 +1,10 @@
 using System;
-using UnityEngine;
 
-[Serializable]
+/// <summary>
+/// Allows user info from a JSON response to be stored in a type safe and specific instance.
+/// </summary>
+
+[Serializable] // Means that data can be parsed and stored within an instance of this class of creation.
 public class User
 {
     public string id;

--- a/Assets/Scripts/API/Types/User.cs.meta
+++ b/Assets/Scripts/API/Types/User.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8f0539bea2111f243be6b7e96404177a

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -7,6 +7,9 @@ public class GameManager : MonoBehaviour
 {
     public static GameManager Instance { get; private set; }
 
+    private User user;
+    public User  User { get => user; set => user = value; }
+
     [SerializeField]
     private int startingMoney = 100; //change to whatever we want
 

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -7,6 +7,12 @@ public class GameManager : MonoBehaviour
 {
     public static GameManager Instance { get; private set; }
 
+    [SerializeField] 
+    private string apiUrl;
+
+    [SerializeField]
+    private string username;
+
     private User user;
     public User  User { get => user; set => user = value; }
 
@@ -38,6 +44,12 @@ public class GameManager : MonoBehaviour
 
     private void Initialize()
     {
+        GetUser();
         Money = startingMoney;
+    }
+
+    private async void GetUser()
+    {
+        User = await HTTPRequests.Get<User>($"{apiUrl}/users/{username}");
     }
 }

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -39,12 +39,15 @@ public class GameManager : MonoBehaviour
 
         Instance = this;
         DontDestroyOnLoad(gameObject);
-        Initialize();
+        StartCoroutine(nameof(Initialize));
     }
 
-    private void Initialize()
+    private IEnumerator Initialize()
     {
         GetUser();
+
+        yield return new WaitUntil(() => User != null);
+
         Money = startingMoney;
     }
 


### PR DESCRIPTION
# Issue
As a player, I want some way to connect to a user, so that I can play the game properly and save my information.
# Use
For the player to interact with the game properly, they need some connection to the API and database. The easiest way to accomplish this is by providing the player with a test user when they load the game. This means that they don't need create a user to start the game, but it is only a temporary measure. If every player were to use the same user it would get quite chaotic quite quickly.