### PR TITLE
Hotfix sprint 3

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -362,74 +362,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &90669452
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: -8679921383154817045, guid: c1bff296aa1959044abb3b5cd2f3d76c,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -32.442
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: c1bff296aa1959044abb3b5cd2f3d76c,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.8249
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: c1bff296aa1959044abb3b5cd2f3d76c,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -39.407
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: c1bff296aa1959044abb3b5cd2f3d76c,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.7071068
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: c1bff296aa1959044abb3b5cd2f3d76c,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0.7071068
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: c1bff296aa1959044abb3b5cd2f3d76c,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: c1bff296aa1959044abb3b5cd2f3d76c,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: c1bff296aa1959044abb3b5cd2f3d76c,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: c1bff296aa1959044abb3b5cd2f3d76c,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: c1bff296aa1959044abb3b5cd2f3d76c,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: c1bff296aa1959044abb3b5cd2f3d76c,
-        type: 3}
-      propertyPath: m_Name
-      value: Food_Box_01
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: c1bff296aa1959044abb3b5cd2f3d76c, type: 3}
 --- !u!1 &96840608
 GameObject:
   m_ObjectHideFlags: 0
@@ -2190,11 +2122,19 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 889053399}
   m_OnClick:
     m_PersistentCalls:
-      m_Calls: [{m_Target: {fileID: 586006308}, m_TargetAssemblyTypeName: 'StoreManager,
-            Assembly-CSharp', m_MethodName: TryPurchaseStock, m_Mode: 1, m_Arguments: {
-            m_ObjectArgument: {fileID: 0}, m_ObjectArgumentAssemblyTypeName: 'UnityEngine.Object,
-              UnityEngine', m_IntArgument: 0, m_FloatArgument: 0, m_StringArgument: '',
-            m_BoolArgument: 0}, m_CallState: 2}]
+      m_Calls:
+      - m_Target: {fileID: 586006308}
+        m_TargetAssemblyTypeName: StoreManager, Assembly-CSharp
+        m_MethodName: TryPurchaseStock
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!114 &889053399
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3544,74 +3484,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1436294303}
   m_CullTransparentMesh: 1
---- !u!1001 &1526712231
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: -8679921383154817045, guid: 8e8a2cfe4cca10f40b3ebf12112206e6,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -32.67902
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 8e8a2cfe4cca10f40b3ebf12112206e6,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.2233
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 8e8a2cfe4cca10f40b3ebf12112206e6,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -39.352562
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 8e8a2cfe4cca10f40b3ebf12112206e6,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.7071068
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 8e8a2cfe4cca10f40b3ebf12112206e6,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0.7071068
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 8e8a2cfe4cca10f40b3ebf12112206e6,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 8e8a2cfe4cca10f40b3ebf12112206e6,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 8e8a2cfe4cca10f40b3ebf12112206e6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 8e8a2cfe4cca10f40b3ebf12112206e6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 8e8a2cfe4cca10f40b3ebf12112206e6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: 8e8a2cfe4cca10f40b3ebf12112206e6,
-        type: 3}
-      propertyPath: m_Name
-      value: Bottle_01
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 8e8a2cfe4cca10f40b3ebf12112206e6, type: 3}
 --- !u!1 &1574611377
 GameObject:
   m_ObjectHideFlags: 0
@@ -3719,74 +3591,6 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1574611377}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!1001 &1579526680
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: -8679921383154817045, guid: 03bc099a9edb8d040ac0dc12fb480c87,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -32.94739
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 03bc099a9edb8d040ac0dc12fb480c87,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.5249
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 03bc099a9edb8d040ac0dc12fb480c87,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -39.35185
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 03bc099a9edb8d040ac0dc12fb480c87,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.7071068
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 03bc099a9edb8d040ac0dc12fb480c87,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0.7071068
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 03bc099a9edb8d040ac0dc12fb480c87,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 03bc099a9edb8d040ac0dc12fb480c87,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 03bc099a9edb8d040ac0dc12fb480c87,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 03bc099a9edb8d040ac0dc12fb480c87,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 03bc099a9edb8d040ac0dc12fb480c87,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: 03bc099a9edb8d040ac0dc12fb480c87,
-        type: 3}
-      propertyPath: m_Name
-      value: Can_01
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 03bc099a9edb8d040ac0dc12fb480c87, type: 3}
 --- !u!1 &1580009834
 GameObject:
   m_ObjectHideFlags: 0
@@ -4695,74 +4499,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1834146837}
   m_CullTransparentMesh: 1
---- !u!1001 &1839423567
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: -8679921383154817045, guid: 28a05412846c07f4491cfd1626476c35,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -32.69
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 28a05412846c07f4491cfd1626476c35,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.099999905
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 28a05412846c07f4491cfd1626476c35,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -39.39
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 28a05412846c07f4491cfd1626476c35,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 28a05412846c07f4491cfd1626476c35,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 28a05412846c07f4491cfd1626476c35,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 28a05412846c07f4491cfd1626476c35,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 28a05412846c07f4491cfd1626476c35,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 28a05412846c07f4491cfd1626476c35,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 28a05412846c07f4491cfd1626476c35,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: 28a05412846c07f4491cfd1626476c35,
-        type: 3}
-      propertyPath: m_Name
-      value: Shelf_01
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 28a05412846c07f4491cfd1626476c35, type: 3}
 --- !u!1 &1864946302
 GameObject:
   m_ObjectHideFlags: 0
@@ -5516,6 +5252,7 @@ SceneRoots:
   - {fileID: 410087041}
   - {fileID: 832575519}
   - {fileID: 1305344629}
+  - {fileID: 220861225}
   - {fileID: 775283612}
   - {fileID: 586006309}
   - {fileID: 1124159751}
@@ -5526,8 +5263,3 @@ SceneRoots:
   - {fileID: 46972656}
   - {fileID: 2014696027}
   - {fileID: 699043603}
-  - {fileID: 1839423567}
-  - {fileID: 1526712231}
-  - {fileID: 1579526680}
-  - {fileID: 90669452}
-  - {fileID: 220861225}

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -450,7 +450,7 @@ MonoBehaviour:
       m_Calls: []
   apiUrl: https://gts-api-p9ar.onrender.com/api
   username: dave
-  startingMoney: 100
+  startingMoney: 70
 --- !u!4 &220861225
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/API/Types/User.cs
+++ b/Assets/Scripts/API/Types/User.cs
@@ -1,4 +1,5 @@
 using System;
+using UnityEngine;
 
 /// <summary>
 /// Allows user info from a JSON response to be stored in a type safe and specific instance.
@@ -9,5 +10,17 @@ public class User
 {
     public string id;
     public string name;
-    public double money;
+    private double money;
+    public double Money
+    {
+        get => money;
+        set
+        {
+            money = value;
+
+            Debug.Log($"{name}: {money:c}");
+
+            // Update the API with the new money value;
+        }
+    }
 }

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -17,7 +17,13 @@ public class GameManager : MonoBehaviour
     private string username;
 
     private User user;
-    public User  User { get => user; set => user = value; }
+    public User User { 
+        get => user; 
+        set 
+        {
+            user = value;
+        }
+    }
 
     [SerializeField]
     private int startingMoney = 100; //change to whatever we want
@@ -30,9 +36,15 @@ public class GameManager : MonoBehaviour
         {
             money = value;
             OnMoneyChange?.Invoke();
+
             // can add more stuff here, eg updating UI etc later on
+            if (user != null) 
+            { 
+                user.Money = money;
+            }
         }
     }
+
     void Awake()
     {
         if (Instance != null) //Ensures there is only one instance of GM at once

--- a/Assets/Scripts/InventoryManager.cs
+++ b/Assets/Scripts/InventoryManager.cs
@@ -139,7 +139,9 @@ public class InventoryManager : MonoBehaviour
 
         playerHeldItem = Instantiate(placeableObject.prefab, playerHeldItemParent.transform);
         playerHeldItemParent.transform.localScale = ((int)placeableObject.type) == 0 ? new Vector3(stockScale, stockScale, stockScale) : new Vector3(structureScale, structureScale, structureScale);
-        playerHeldItem.GetComponent<RandomSell>().enabled = false;
+        RandomSell randomSell = playerHeldItem.GetComponent<RandomSell>();
+        if (randomSell != null)
+            randomSell.enabled = false;
         
         heldObject = placeableObject;
     }

--- a/Assets/Scripts/InventoryManager.cs
+++ b/Assets/Scripts/InventoryManager.cs
@@ -125,6 +125,7 @@ public class InventoryManager : MonoBehaviour
 
         playerHeldItem = Instantiate(placeableObject.prefab, playerHeldItemParent.transform);
         playerHeldItemParent.transform.localScale = ((int)placeableObject.type) == 0 ? new Vector3(stockScale, stockScale, stockScale) : new Vector3(structureScale, structureScale, structureScale);
+        playerHeldItem.GetComponent<RandomSell>().enabled = false;
         
         heldObject = placeableObject;
     }

--- a/Assets/Scripts/InventoryManager.cs
+++ b/Assets/Scripts/InventoryManager.cs
@@ -21,7 +21,21 @@ public class InventoryManager : MonoBehaviour
 
     // The data stored about each object that is held
     private PlaceableObject heldObject;
-    public PlaceableObject HeldObject { get => heldObject; set => heldObject = value; }
+    public PlaceableObject HeldObject
+    {
+        get
+        {
+            if (heldObject == null)
+                ClearHandItem();
+            return heldObject;
+        }
+        set
+        {
+            heldObject = value;
+            if (heldObject == null)
+                ClearHandItem();
+        }
+    }
     private int tabIndex;
     private List<GameObject> gridObjectDisplayList = new List<GameObject>();
     // List of items currently displayed in GUI

--- a/Assets/Scripts/PlaceObject.cs
+++ b/Assets/Scripts/PlaceObject.cs
@@ -40,6 +40,9 @@ public class PlaceObject : MonoBehaviour
 
         InventoryManager.Instance.HeldObject.count--;
         if (InventoryManager.Instance.HeldObject.count <= 0)
+        {
+            InventoryManager.Instance.InventoryPlaceableObjects.Remove(InventoryManager.Instance.HeldObject);
             InventoryManager.Instance.HeldObject = null;
+        }
     }
 }

--- a/Assets/Scripts/PlaceObject.cs
+++ b/Assets/Scripts/PlaceObject.cs
@@ -37,5 +37,9 @@ public class PlaceObject : MonoBehaviour
             transform.position.x,
             placedObject.transform.position.y,
             transform.position.z));
+
+        InventoryManager.Instance.HeldObject.count--;
+        if (InventoryManager.Instance.HeldObject.count <= 0)
+            InventoryManager.Instance.HeldObject = null;
     }
 }

--- a/Assets/Scripts/StoreManager.cs
+++ b/Assets/Scripts/StoreManager.cs
@@ -53,11 +53,13 @@ public class StoreManager : MonoBehaviour
             totalCostText.text = $"Total: ${totalCost}";
             UpdateMoneyText();
             buyButtonText.text = "Buy!";
+            InputSystem.actions.FindAction("Place").Disable();
         }
         else
         {
             Cursor.lockState = CursorLockMode.Locked;
             totalCost = 0;
+            InputSystem.actions.FindAction("Place").Enable();
         }
     }
 


### PR DESCRIPTION
# Use
Through developing new features, some simple yet frustrating for the player bugs and issues have been created. So, to ensure the sprint increment is useful and usable for players, a hotfix is required.
# Changes
- Removed temporary props
- Player now receives `startingMoney` on game start
- User money is now updated whenever money is changed
- Held item no longer sells itself after equiping
- Held item quantity is now descreased upon being placed; if the quantity is zero, item is removed from hand
- Fixed player inability to place purchased shelves
- Fixed zero stock items remaining in the player's inventory
- Disabled item placement whilst the store is open